### PR TITLE
Removed 'querystring-number' dependency

### DIFF
--- a/lib/index.ts
+++ b/lib/index.ts
@@ -1,4 +1,3 @@
-import qs from "querystring-number";
 const cache = {} as any;
 
 export interface QueryGet<T extends { query: object }> {
@@ -95,7 +94,8 @@ const makeMethod = async (
   }
   let url = "/" + name;
   if (query) {
-    url += "?" + qs.stringify(query);
+	const searchParams = new URLSearchParams(query)
+	url += "?" + searchParams;
   }
 
   return baseApi(url, body, { ...baseOptions, ...options, method });

--- a/package.json
+++ b/package.json
@@ -29,7 +29,6 @@
   },
   "homepage": "git+https://github.com/ymzuiku/svelte-zero-api.git",
   "dependencies": {
-    "chokidar": "^3.5.2",
-    "querystring-number": "^1.0.8"
+    "chokidar": "^3.5.2"
   }
 }


### PR DESCRIPTION
It caused issues with SvelteKit — and was depreciated since NodeJS has a internal function for the same thing.